### PR TITLE
using swap strategy for font-display

### DIFF
--- a/cdn/hind.css
+++ b/cdn/hind.css
@@ -6,7 +6,7 @@
   font-weight: 300;
   src: local('Hind Light'), local('Hind-Light'), url(./hind-fonts/Rc7GRo3x-113kh9xYghjoFKPGs1ZzpMvnHX-7fPOuAc.woff2) format('woff2');
   unicode-range: U+02BC, U+0900-097F, U+1CD0-1CF6, U+1CF8-1CF9, U+200B-200D, U+20A8, U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FB;
-  font-display: optional;
+  font-display: swap;
 }
 /* latin-ext */
 @font-face {
@@ -15,7 +15,7 @@
   font-weight: 300;
   src: local('Hind Light'), local('Hind-Light'), url(./hind-fonts/WWCzXbkBuuC4_xgCfWCnVVKPGs1ZzpMvnHX-7fPOuAc.woff2) format('woff2');
   unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
-  font-display: optional;
+  font-display: swap;
 }
 /* latin */
 @font-face {
@@ -24,7 +24,7 @@
   font-weight: 300;
   src: local('Hind Light'), local('Hind-Light'), url(./hind-fonts/j0nw79-SK78CoHOhg6MGGwLUuEpTyoUstqEm5AMlJo4.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215, U+E0FF, U+EFFD, U+F000;
-  font-display: optional;
+  font-display: swap;
 }
 /* devanagari */
 @font-face {
@@ -33,7 +33,7 @@
   font-weight: 400;
   src: local('Hind'), local('Hind-Regular'), url(./hind-fonts/PweUV6zQOwbea1HTWD9UxRTbgVql8nDJpwnrE27mub0.woff2) format('woff2');
   unicode-range: U+02BC, U+0900-097F, U+1CD0-1CF6, U+1CF8-1CF9, U+200B-200D, U+20A8, U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FB;
-  font-display: optional;
+  font-display: swap;
 }
 /* latin-ext */
 @font-face {
@@ -42,7 +42,7 @@
   font-weight: 400;
   src: local('Hind'), local('Hind-Regular'), url(./hind-fonts/_nGZcTICJK7Og5TmI2ZPqxTbgVql8nDJpwnrE27mub0.woff2) format('woff2');
   unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
-  font-display: optional;
+  font-display: swap;
 }
 /* latin */
 @font-face {
@@ -51,7 +51,7 @@
   font-weight: 400;
   src: local('Hind'), local('Hind-Regular'), url(./hind-fonts/Pmrg92KFJKj-hq44c2dqpvesZW2xOQ-xsNqO47m55DA.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215, U+E0FF, U+EFFD, U+F000;
-  font-display: optional;
+  font-display: swap;
 }
 /* devanagari */
 @font-face {
@@ -60,7 +60,7 @@
   font-weight: 500;
   src: local('Hind Medium'), local('Hind-Medium'), url(./hind-fonts/elJJ0vN7rrHbsbleSrwHJlKPGs1ZzpMvnHX-7fPOuAc.woff2) format('woff2');
   unicode-range: U+02BC, U+0900-097F, U+1CD0-1CF6, U+1CF8-1CF9, U+200B-200D, U+20A8, U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FB;
-  font-display: optional;
+  font-display: swap;
 }
 /* latin-ext */
 @font-face {
@@ -69,7 +69,7 @@
   font-weight: 500;
   src: local('Hind Medium'), local('Hind-Medium'), url(./hind-fonts/nnS4i7BKxGmIfxNrHr-vZFKPGs1ZzpMvnHX-7fPOuAc.woff2) format('woff2');
   unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
-  font-display: optional;
+  font-display: swap;
 }
 /* latin */
 @font-face {
@@ -78,5 +78,5 @@
   font-weight: 500;
   src: local('Hind Medium'), local('Hind-Medium'), url(./hind-fonts/AVPJIwmCdO7y8S0MQagSagLUuEpTyoUstqEm5AMlJo4.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215, U+E0FF, U+EFFD, U+F000;
-  font-display: optional;
+  font-display: swap;
 }

--- a/cdn/josefin-sans.css
+++ b/cdn/josefin-sans.css
@@ -6,7 +6,7 @@
   font-weight: 100;
   src: local('Josefin Sans Thin'), local('JosefinSans-Thin'), url(./josefin-sans-fonts/q9w3H4aeBxj0hZ8Osfi3d_ZLGUYxk5QQ1Un914Iccq4.woff2) format('woff2');
   unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
-  font-display: optional;
+  font-display: swap;
 }
 /* latin */
 @font-face {
@@ -15,7 +15,7 @@
   font-weight: 100;
   src: local('Josefin Sans Thin'), local('JosefinSans-Thin'), url(./josefin-sans-fonts/q9w3H4aeBxj0hZ8Osfi3dzUBvlJYYQI_sDPKrlKoP9Q.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215, U+E0FF, U+EFFD, U+F000;
-  font-display: optional;
+  font-display: swap;
 }
 /* latin-ext */
 @font-face {
@@ -24,7 +24,7 @@
   font-weight: 300;
   src: local('Josefin Sans Light'), local('JosefinSans-Light'), url(./josefin-sans-fonts/C6HYlRF50SGJq1XyXj04z7sKtFnhOiVZh9MDlvO1Vys.woff2) format('woff2');
   unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
-  font-display: optional;
+  font-display: swap;
 }
 /* latin */
 @font-face {
@@ -33,7 +33,7 @@
   font-weight: 300;
   src: local('Josefin Sans Light'), local('JosefinSans-Light'), url(./josefin-sans-fonts/C6HYlRF50SGJq1XyXj04z0ZRWJQ0UjzR2Uv6RollX_g.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215, U+E0FF, U+EFFD, U+F000;
-  font-display: optional;
+  font-display: swap;
 }
 /* latin-ext */
 @font-face {
@@ -42,7 +42,7 @@
   font-weight: 400;
   src: local('Josefin Sans'), local('JosefinSans'), url(./josefin-sans-fonts/xgzbb53t8j-Mo-vYa23n5ojoYw3YTyktCCer_ilOlhE.woff2) format('woff2');
   unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
-  font-display: optional;
+  font-display: swap;
 }
 /* latin */
 @font-face {
@@ -51,5 +51,5 @@
   font-weight: 400;
   src: local('Josefin Sans'), local('JosefinSans'), url(./josefin-sans-fonts/xgzbb53t8j-Mo-vYa23n5hampu5_7CjHW5spxoeN3Vs.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215, U+E0FF, U+EFFD, U+F000;
-  font-display: optional;
+  font-display: swap;
 }


### PR DESCRIPTION
Actually I want `swap`:

https://developers.google.com/web/updates/2016/02/font-display

> This means the browser draws text immediately with a fallback if the font face isn’t loaded, but swaps the font face in as soon as it loads.